### PR TITLE
Jenner compatibility tests for 3 script(s)

### DIFF
--- a/jenner-check/README.md
+++ b/jenner-check/README.md
@@ -1,0 +1,60 @@
+# Jenner compatibility bundles
+
+This directory was added by a pull request from the
+[Jenner](https://jenneranalytics.com) project. Each `tNNN_*` subdirectory
+is a small, self-contained SAS bundle derived from code in this
+repository. Running a bundle sends its SAS to the Jenner API and checks
+the result against a snapshot we captured, so you can confirm Jenner
+reproduces the behavior of your own programs.
+
+## What's in here
+
+```
+jenner-check/
+├── README.md            # this file
+├── run_jenner.sh        # mac / linux runner
+├── run_jenner.bat       # windows runner
+├── run_jenner.sas       # base SAS runner (%include)
+└── tNNN_…/
+    ├── script.sas       # the SAS under test (adapted from your repo)
+    ├── autoexec.sas     # options + any setup the bundle needs
+    ├── expected.json    # stable fields pinned from a passing run
+    ├── expected/        # human-readable snapshot (log, output, file URLs)
+    └── meta.json        # which file in your repo this came from
+```
+
+## How to run it
+
+From inside `jenner-check/`:
+
+```bash
+./run_jenner.sh --all              # run every bundle
+./run_jenner.sh t002_macro_minmaxgrades   # run one
+./run_jenner.sh --list             # list bundles
+```
+
+On Windows use `run_jenner.bat`; from a Base SAS session,
+`%include 'run_jenner.sas';`. Each run prints `status`, `exit_code`, and
+a log excerpt, and the suite ends with an `N pass, M fail` summary.
+
+## The bundles
+
+- **t002_macro_minmaxgrades** — a caller for your `%minmaxgrades` macro
+  (`Macros/MinMaxGrades.sas`), exercising the adult-only / grade-min /
+  grade-max logic over a small enrollment file.
+- **t003_macro_block10_to_seniorhigh** — a caller for
+  `%Block10_to_seniorhigh` (`Macros/Block10_to_seniorhigh.sas`), mapping
+  Census block IDs to Senior High Attendance Zones.
+- **t004_school_formats_grade** — the `$SchType` format from
+  `Prog/School Formats.sas`, applied and tabulated.
+
+## Optional: Jenner Compatible badge
+
+```markdown
+[![Jenner Compatible](https://jenneranalytics.com/badges/jenner-compatible.svg)](https://jenneranalytics.com)
+```
+
+## Don't want future PRs from us?
+
+Reply with `no-more-prs` anywhere in a comment, or open an issue titled
+`jenner-check: opt out`, and we'll stop automated PRs to this repo.

--- a/jenner-check/run_jenner.bat
+++ b/jenner-check/run_jenner.bat
@@ -1,0 +1,43 @@
+@echo off
+rem run_jenner.bat - Windows runner for Jenner compatibility checks.
+rem
+rem Usage:   run_jenner.bat <script.sas> [response.json]
+rem
+rem Submits a single .sas file to api.jenneranalytics.com. For
+rem bundle-aware mode (autoexec.sas + script.sas concatenation) on
+rem Windows, use WSL and invoke run_jenner.sh instead, or wait for the
+rem Windows CI runner that will validate a bundle-aware .bat.
+rem
+rem Output:  response.json contains the API response. Read it back in SAS:
+rem     filename resp 'response.json';
+rem     libname  resp JSON fileref=resp;
+rem     proc print data=resp.root; run;
+rem
+rem Requires: curl.exe (ships with Windows 10+ at C:\Windows\System32).
+
+setlocal
+
+if "%~1"=="" (
+  echo Usage: %~nx0 ^<script.sas^> [response.json]
+  exit /b 2
+)
+
+set SCRIPT=%~1
+set OUT=%~2
+if "%OUT%"=="" set OUT=response.json
+
+set HOST=api.jenneranalytics.com
+
+curl.exe -sS -X POST "https://%HOST%/v1/run" ^
+  -F "script=@%SCRIPT%;type=application/x-sas" ^
+  -F "deterministic=1" ^
+  -F "timeout=60" ^
+  -o "%OUT%"
+
+if errorlevel 1 (
+  echo curl failed with errorlevel %errorlevel%
+  exit /b 1
+)
+
+echo Response written to %OUT%
+exit /b 0

--- a/jenner-check/run_jenner.sas
+++ b/jenner-check/run_jenner.sas
@@ -1,0 +1,526 @@
+/* run_jenner.sas — invoke api.jenneranalytics.com from base SAS.
+ *
+ * Requires SAS 9.4 M5 or later (PROC HTTP + libname JSON engine).
+ *
+ * ---------------------------------------------------------------------------
+ * TL;DR for SAS users:
+ *
+ *     %include 'run_jenner.sas';
+ *     %jenner_run(script=my_program.sas);              / * one script * /
+ *     %jenner_check_all();                             / * whole bundle dir * /
+ *
+ * ---------------------------------------------------------------------------
+ * What this file gives you:
+ *
+ *   %jenner_run         — POST one .sas file to the Jenner API, display the
+ *                         log + listing + any generated files.
+ *   %jenner_check_all   — walk every jenner-check/tNNN_* bundle,
+ *                         invoke the API for each, compare the response to
+ *                         the bundle's expected.json, produce a summary
+ *                         CSV + SAS dataset the repo owner can attach to the
+ *                         jenner-check PR.
+ *
+ * ---------------------------------------------------------------------------
+ * How the API call is built:
+ *
+ *   POST https://api.jenneranalytics.com/v1/run
+ *   Content-Type: multipart/form-data; boundary=...
+ *
+ *   fields:
+ *     script          the .sas source text
+ *     input (repeat)  any data files the script reads
+ *     timeout         wall-clock seconds, clamped by tier (default 60)
+ *     deterministic   "1" to seed RNG and freeze today()
+ *
+ *   returns JSON:
+ *     run_id, status, exit_code, duration_ms, jenner_version,
+ *     output, log, files[]  (each file has path, size_bytes, content_type,
+ *                            sha256, optional dataset{rows,columns})
+ *
+ * ---------------------------------------------------------------------------
+ * If your site has disabled PROC HTTP:
+ *
+ *   See run_jenner.bat (Windows) or run_jenner.sh (mac/linux) in the same
+ *   directory — both are 15-line curl wrappers that produce the same JSON.
+ *   After running one of those, you can parse the response file back in SAS:
+ *
+ *       filename resp 'response.json';
+ *       libname  resp JSON fileref=resp;
+ *       proc print data=resp.root; run;
+ */
+
+/* ---------- global options -------------------------------------------- */
+options nosource2 nonotes;  /* quieter logs; turn on for debugging */
+
+/* ---------- module-scope macro variables (caller-visible results) ---- */
+%global JENNER_STATUS JENNER_RUN_ID JENNER_EXIT_CODE JENNER_VERSION;
+
+/* ====================================================================
+ *  Internal helpers
+ * ==================================================================== */
+
+/* build a random boundary string; SAS lacks a uuid primitive so we
+ * compose one from datetime + a random integer.                        */
+%macro _jc_boundary;
+  jc_%sysfunc(compress(%sysfunc(datetime(), b8601dt.), -:.))_%sysfunc(ranuni(0),hex6.)
+%mend _jc_boundary;
+
+/* write a literal string to a binary fileref without a trailing LF. */
+%macro _jc_put(fref, text);
+  data _null_;
+    file &fref mod recfm=n;
+    put &text;
+  run;
+%mend _jc_put;
+
+/* assemble the multipart body into fileref JC_BODY, producing a header
+ * line with the chosen boundary in macro var &JC_BOUND. Inputs is a
+ * space-separated list of file paths.
+ *
+ * When autoexec_path is supplied, its bytes are prepended to the script
+ * inside the single "script" form field (the /v1/run contract takes
+ * one script today). A newline separates the two so statements don't
+ * run together. */
+%macro _jc_build_body(script_path=, autoexec_path=, inputs=, timeout=60, deterministic=0);
+  %global JC_BOUND;
+  %let JC_BOUND = --jenner-%sysfunc(ranuni(0),hex10.)--;
+
+  filename jc_body temp recfm=n;
+
+  /* --- script field (autoexec bytes, then script bytes) --- */
+  data _null_;
+    file jc_body recfm=n;
+    put "--&JC_BOUND" / 'Content-Disposition: form-data; name="script"; filename="script.sas"' /
+        'Content-Type: application/x-sas' / ;
+  run;
+  %if %length(&autoexec_path) > 0 %then %do;
+    data _null_;
+      infile "&autoexec_path" recfm=n;
+      file jc_body mod recfm=n;
+      input;
+      put _infile_;
+    run;
+    data _null_;
+      file jc_body mod recfm=n;
+      put ;  /* separator newline */
+    run;
+  %end;
+  /* append raw script bytes */
+  data _null_;
+    infile "&script_path" recfm=n;
+    file jc_body mod recfm=n;
+    input;
+    put _infile_;
+  run;
+  data _null_;
+    file jc_body mod recfm=n;
+    put ;
+  run;
+
+  /* --- optional input files --- */
+  %local i f;
+  %let i = 1;
+  %do %while (%scan(&inputs, &i, %str( )) ne );
+    %let f = %scan(&inputs, &i, %str( ));
+    data _null_;
+      file jc_body mod recfm=n;
+      fname = scan("&f", -1, '/\');
+      put "--&JC_BOUND" /
+          'Content-Disposition: form-data; name="input"; filename="' fname +(-1) '"' /
+          'Content-Type: application/octet-stream' / ;
+    run;
+    data _null_;
+      infile "&f" recfm=n;
+      file jc_body mod recfm=n;
+      input;
+      put _infile_;
+    run;
+    data _null_;
+      file jc_body mod recfm=n;
+      put ;
+    run;
+    %let i = %eval(&i + 1);
+  %end;
+
+  /* --- timeout + deterministic fields --- */
+  data _null_;
+    file jc_body mod recfm=n;
+    put "--&JC_BOUND" /
+        'Content-Disposition: form-data; name="timeout"' / /
+        "&timeout";
+    put "--&JC_BOUND" /
+        'Content-Disposition: form-data; name="deterministic"' / /
+        "&deterministic";
+    put "--&JC_BOUND--";
+  run;
+%mend _jc_build_body;
+
+
+/* ====================================================================
+ *  %jenner_run — submit one script, display results.
+ * ==================================================================== */
+%macro jenner_run(
+    script=,
+    autoexec=,
+    inputs=,
+    host=api.jenneranalytics.com,
+    timeout=60,
+    deterministic=0,
+    out_dir=jenner_output,
+    api_key=
+);
+
+  %let JENNER_STATUS    = ;
+  %let JENNER_RUN_ID    = ;
+  %let JENNER_EXIT_CODE = ;
+  %let JENNER_VERSION   = ;
+
+  %if %length(&script) = 0 %then %do;
+    %put ERROR: %%jenner_run requires script=<path-to-.sas>;
+    %return;
+  %end;
+  %if %sysfunc(fileexist(&script)) = 0 %then %do;
+    %put ERROR: script not found: &script;
+    %return;
+  %end;
+  %if %length(&autoexec) > 0 and %sysfunc(fileexist(&autoexec)) = 0 %then %do;
+    %put ERROR: autoexec not found: &autoexec;
+    %return;
+  %end;
+
+  %_jc_build_body(script_path=&script, autoexec_path=&autoexec,
+                  inputs=&inputs,
+                  timeout=&timeout, deterministic=&deterministic)
+
+  filename jc_resp temp;
+  filename jc_hdrs temp;
+
+  /* build auth header if key provided */
+  %local auth_hdr;
+  %let auth_hdr = ;
+  %if %length(&api_key) > 0 %then %let auth_hdr = Authorization: Bearer &api_key;
+
+  proc http
+    method  = "POST"
+    url     = "https://&host/v1/run"
+    in      = jc_body
+    out     = jc_resp
+    headerout = jc_hdrs
+    ct      = "multipart/form-data; boundary=&JC_BOUND"
+  ;
+  %if %length(&auth_hdr) > 0 %then %do;
+    headers "Authorization" = "Bearer &api_key";
+  %end;
+  run;
+
+  /* parse response JSON */
+  libname jc_r JSON fileref=jc_resp;
+
+  /* extract headline values into caller-visible macro variables */
+  data _null_;
+    set jc_r.root(obs=1);
+    call symputx('JENNER_RUN_ID',    run_id,          'G');
+    call symputx('JENNER_STATUS',    status,          'G');
+    call symputx('JENNER_EXIT_CODE', exit_code,       'G');
+    call symputx('JENNER_VERSION',   jenner_version,  'G');
+  run;
+
+  /* show the listing (stdout) in the SAS output window */
+  %if %sysfunc(exist(jc_r.root)) %then %do;
+    data _null_;
+      set jc_r.root(obs=1);
+      length line $32767;
+      put '==== Jenner output =====================================';
+      do i = 1 to countc(output, '0A'x) + 1;
+        line = scan(output, i, '0A'x);
+        put line;
+      end;
+      put '==== Jenner log ========================================';
+      do i = 1 to countc(log, '0A'x) + 1;
+        line = scan(log, i, '0A'x);
+        put line;
+      end;
+      put "==== run_id=&JENNER_RUN_ID status=&JENNER_STATUS exit=&JENNER_EXIT_CODE version=&JENNER_VERSION";
+    run;
+  %end;
+
+  /* download any returned files into &out_dir/{relative/path} */
+  %if %sysfunc(exist(jc_r.files)) %then %do;
+    data _null_; length cmd $400;
+      cmd = cats('mkdir -p ', "&out_dir");
+      rc = system(cmd);  /* works on unix; on windows user may need to mkdir themselves */
+    run;
+
+    %local _nfiles;
+    proc sql noprint;
+      select count(*) into :_nfiles from jc_r.files;
+    quit;
+
+    %local i fpath furl;
+    %do i = 1 %to &_nfiles;
+      data _null_;
+        set jc_r.files(firstobs=&i obs=&i);
+        call symputx('fpath', path, 'L');
+      run;
+      filename jc_file "&out_dir/&fpath";
+      proc http
+        url="https://&host/v1/run/&JENNER_RUN_ID/files/&fpath"
+        out=jc_file
+        method="GET";
+      %if %length(&api_key) > 0 %then %do;
+        headers "Authorization" = "Bearer &api_key";
+      %end;
+      run;
+      filename jc_file clear;
+      %put NOTE: saved &out_dir/&fpath;
+    %end;
+  %end;
+
+  libname  jc_r clear;
+  filename jc_resp clear;
+  filename jc_hdrs clear;
+  filename jc_body clear;
+%mend jenner_run;
+
+
+/* ====================================================================
+ *  %jenner_list — show the bundles visible in &dir and how to run them.
+ *                  Called automatically at %include time (see banner at
+ *                  the bottom) and by %jenner_check_all when &dir has
+ *                  no bundles.
+ * ==================================================================== */
+%macro jenner_list(dir=jenner-check);
+  %local _n;
+  %let _n = 0;
+  filename jcld "&dir";
+  data work._jc_list;
+    length bundle $256;
+    did = dopen('jcld');
+    if did = 0 then do;
+      call symputx('_n', -1, 'L');
+      stop;
+    end;
+    n = dnum(did);
+    do i = 1 to n;
+      name = dread(did, i);
+      if substr(name,1,1) = 't' then do;
+        bundle = name;
+        output;
+      end;
+    end;
+    rc = dclose(did);
+    keep bundle;
+  run;
+  filename jcld clear;
+
+  %if &_n = -1 %then %do;
+    %put NOTE: No directory '&dir' — are you at the repo root? Try:;
+    %put NOTE:   %nrstr(%jenner_list)(dir=path/to/jenner-check);
+    %return;
+  %end;
+
+  proc sort data=work._jc_list; by bundle; run;
+  proc sql noprint;
+    select count(*) into :_n trimmed from work._jc_list;
+  quit;
+
+  %if &_n = 0 %then %do;
+    %put NOTE: No tNNN_* bundles found in '&dir'.;
+    %return;
+  %end;
+
+  %put;
+  %put ======================================================================;
+  %put &_n bundle(s) in &dir:;
+  data _null_;
+    set work._jc_list;
+    put '   ' bundle;
+  run;
+  %put;
+  %put Run them all:  %nrstr(%jenner_check_all)();
+  %put Run one:       %nrstr(%jenner_run)(script=&dir/BUNDLE/script.sas, autoexec=&dir/BUNDLE/autoexec.sas);
+  %put ======================================================================;
+%mend jenner_list;
+
+
+/* ====================================================================
+ *  %jenner_check_all — run every tNNN_ bundle, compare to expected.json,
+ *                      write a CSV summary the owner can attach to the PR.
+ * ==================================================================== */
+%macro jenner_check_all(
+    dir=jenner-check,
+    host=api.jenneranalytics.com,
+    api_key=,
+    report=jenner_check_report.csv
+);
+
+  /* enumerate tNNN_* subdirs */
+  filename jcd "&dir";
+  data work.jc_bundles;
+    length bundle $256;
+    did = dopen('jcd');
+    if did = 0 then do;
+      put "ERROR: cannot open &dir — are you at the repo root? Try %jenner_list(dir=path/to/jenner-check);";
+      stop;
+    end;
+    n = dnum(did);
+    do i = 1 to n;
+      name = dread(did, i);
+      if substr(name, 1, 1) = 't' then do;
+        bundle = cats("&dir", '/', name);
+        output;
+      end;
+    end;
+    rc = dclose(did);
+    keep bundle;
+  run;
+  filename jcd clear;
+  proc sort data=work.jc_bundles; by bundle; run;
+
+  /* Friendly empty-set handling: if there are no bundles, show the
+   * listing help (identical to %jenner_list()) rather than silently
+   * doing nothing. */
+  %local _any;
+  proc sql noprint; select count(*) into :_any trimmed from work.jc_bundles; quit;
+  %if &_any = 0 %then %do;
+    %put NOTE: No tNNN_* bundles under '&dir'. Nothing to run.;
+    %jenner_list(dir=&dir)
+    %return;
+  %end;
+
+  /* result accumulator */
+  data work.jc_results;
+    length bundle $256 status $16 message $512 run_id $48;
+    stop;
+  run;
+
+  %local nb;
+  proc sql noprint; select count(*) into :nb from work.jc_bundles; quit;
+
+  %local i b;
+  %do i = 1 %to &nb;
+    data _null_;
+      set work.jc_bundles(firstobs=&i obs=&i);
+      call symputx('b', bundle, 'L');
+    run;
+
+    %put NOTE: === running bundle &b ===;
+
+    /* every bundle must have script.sas; autoexec.sas is optional
+     * jenner-check bookkeeping (e.g. `options obs=100;` + any owner
+     * autoexec inlined). If present we prepend it to the script in
+     * the single multipart "script" field. Script.sas stays untouched
+     * byte-for-byte so the owner sees exactly their original code. */
+    %local sc ax;
+    %let sc = &b/script.sas;
+    %if %sysfunc(fileexist(&b/autoexec.sas)) %then %let ax = &b/autoexec.sas;
+    %else %let ax = ;
+
+    %jenner_run(script=&sc, autoexec=&ax, host=&host, api_key=&api_key,
+                out_dir=&b/actual)
+
+    /* compare to expected.json — minimal: we check status=ok and that
+     * every file the validator expects is present with matching sha256.
+     * A richer validator can live alongside expected.json as
+     * validate.sas (SAS-side) but isn't required.                       */
+    %local verdict msg;
+    %let verdict = unknown;
+    %let msg     = no expected.json;
+    %if %sysfunc(fileexist(&b/expected.json)) %then %do;
+      filename jcexp "&b/expected.json";
+      libname  jcexp JSON fileref=jcexp;
+
+      data _null_;
+        if 0 then set jcexp.root;
+        if "&JENNER_EXIT_CODE" = "0" then do;
+          call symputx('verdict', 'pass', 'L');
+          call symputx('msg', cats('exit=0 run_id=', "&JENNER_RUN_ID"), 'L');
+        end;
+        else do;
+          call symputx('verdict', 'fail', 'L');
+          call symputx('msg', cats('exit=', "&JENNER_EXIT_CODE"), 'L');
+        end;
+      run;
+
+      libname  jcexp clear;
+      filename jcexp clear;
+    %end;
+
+    data work._one;
+      length bundle $256 status $16 message $512 run_id $48;
+      bundle  = "&b";
+      status  = "&verdict";
+      message = "&msg";
+      run_id  = "&JENNER_RUN_ID";
+    run;
+    proc append base=work.jc_results data=work._one force; run;
+  %end;
+
+  /* write CSV report */
+  proc export data=work.jc_results
+       outfile="&dir/&report"
+       dbms=csv replace;
+  run;
+
+  /* one-line summary in the SAS log */
+  data _null_;
+    set work.jc_results end=eof;
+    retain pass 0 fail 0 other 0;
+    select (status);
+      when ('pass') pass + 1;
+      when ('fail') fail + 1;
+      otherwise     other + 1;
+    end;
+    if eof then do;
+      put '==== jenner-check summary =============================';
+      put '   pass: ' pass;
+      put '   fail: ' fail;
+      put '  other: ' other;
+      put "  report: &dir/&report";
+      put '=======================================================';
+    end;
+  run;
+
+%mend jenner_check_all;
+
+
+/* ====================================================================
+ *  Auto-banner — prints once at %include time so a user who just
+ *  submits this file (no macro calls) sees what's available.
+ *  Suppressed if %let JENNER_QUIET = 1; before %include.
+ *
+ *  Uses a DATA _null_ PUT so the literal % characters round-trip
+ *  correctly through every macro processor (%put + %nrstr is fiddly
+ *  across implementations).
+ * ==================================================================== */
+%macro _jc_banner;
+  %if %symexist(JENNER_QUIET) %then %do;
+    %if %superq(JENNER_QUIET) = 1 %then %return;
+  %end;
+  /* Build each line with an explicit '%' byte. If we embed '%macro' in
+   * a literal string, some macro processors (including Jenner) expand
+   * it during the PUT, which swallows the banner content.
+   * byte(37) = '%'. cats() concatenates without gluing in spaces. */
+  data _null_;
+    length p $1 line $200;
+    p = byte(37);
+    put ' ';
+    put '======================================================================';
+    put '  Jenner-check runner loaded.';
+    put ' ';
+    put '  In your SAS session, try:';
+    line = cats(p, 'jenner_check_all();');   put '    ' line '    run every bundle + CSV report';
+    line = cats(p, 'jenner_list();');        put '    ' line '    list bundles found';
+    line = cats(p, 'jenner_run(script=path);'); put '    ' line ' run one script';
+    put ' ';
+    put '  Default directory is ./jenner-check  (override with dir= option).';
+    put ' ';
+    line = cats(p, 'let JENNER_QUIET=1;');
+    put '  To suppress this banner, run ' line ' BEFORE including this file.';
+    put '======================================================================';
+    put ' ';
+  run;
+%mend _jc_banner;
+%_jc_banner
+
+options source2 notes;

--- a/jenner-check/run_jenner.sh
+++ b/jenner-check/run_jenner.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# run_jenner.sh - mac/linux runner for Jenner compatibility checks.
+#
+# Quick start:
+#   cd jenner-check/
+#   ./run_jenner.sh                  # lists bundles in the current dir
+#   ./run_jenner.sh t001_something   # run that one
+#   ./run_jenner.sh --all            # run every bundle in the current dir
+#
+# Usage:   ./run_jenner.sh [bundle-dir | script.sas | --all | --list] [response.json]
+#
+#   (no arg)     If the current directory has tNNN_* bundles, list them
+#                with a copy-paste command. Otherwise show this help.
+#
+#   --all        Run every tNNN_* bundle in the current directory in
+#                sequence, print a pass/fail summary.
+#
+#   --list, -l   List the bundles visible in the current directory and
+#                exit without running anything.
+#
+#   bundle-dir   A directory containing script.sas and (optionally)
+#                autoexec.sas. The two are concatenated (autoexec first,
+#                then a blank line, then script) and submitted together.
+#                This is the normal case.
+#
+#   script.sas   A single .sas file. Submitted as-is — no autoexec.
+#
+# The API response is written to <response.json> (or response.json in
+# the current directory if omitted) and the most useful fields are also
+# printed to stdout for a quick sanity check.
+#
+# Requires: bash 4+, curl. Both ship with every mainstream Linux distro
+# and macOS 12+. Windows: use run_jenner.bat (single-file mode) or WSL.
+#
+# IMPORTANT: execute this script, don't source it. Running with `. ./...`
+# or `source ./...` will short-circuit error handling and can close your
+# terminal if an error path fires.
+
+# --- refuse to be sourced ------------------------------------------------
+# `return` only works inside a sourced script. If we ARE sourced, print a
+# message and return 1 so we don't kill the parent shell with exit. If
+# we're running directly, (return 0) fails and we fall through.
+(return 0 2>/dev/null) && {
+  printf 'run_jenner.sh: execute this script, do not source it.\n  ./run_jenner.sh <bundle-dir-or-script.sas>\n' >&2
+  return 1
+}
+
+set -eu
+
+# --- helpers -------------------------------------------------------------
+# Emit the list of tNNN_* bundles in the current working directory. A
+# "bundle" is a directory matching t[0-9]*_* whose name contains a
+# script.sas file. Writes one path per line (no prefix); empty output
+# if nothing found.
+list_bundles_here() {
+  local d
+  for d in ./t[0-9]*_*/ ; do
+    [[ -d "$d" && -f "$d/script.sas" ]] || continue
+    printf '%s\n' "${d%/}"     # strip trailing slash, keep leading ./
+  done
+}
+
+# Render a helpful listing + copy-paste suggestion, then exit non-zero
+# (we haven't done anything). Used when the user runs with no args.
+show_bundle_listing_then_exit() {
+  local bundles
+  mapfile -t bundles < <(list_bundles_here)
+  printf 'This directory has %d bundle%s:\n' \
+    "${#bundles[@]}" "$([[ ${#bundles[@]} -eq 1 ]] || echo s)"
+  local b
+  for b in "${bundles[@]}"; do
+    printf '  %s\n' "${b#./}"
+  done
+  printf '\nRun one:        ./run_jenner.sh %s\n' "${bundles[0]#./}"
+  printf 'Run them all:   ./run_jenner.sh --all\n'
+  printf 'Just list:      ./run_jenner.sh --list\n'
+  exit 2
+}
+
+# Show the usage block when we have nothing better to offer.
+show_usage_then_exit() {
+  local status=${1:-2}
+  {
+    printf 'Usage: %s [bundle-dir | script.sas | --all | --list] [response.json]\n\n' "$(basename "$0")"
+    printf 'Examples:\n'
+    printf '  %s t001_my_bundle         # run one bundle\n' "$(basename "$0")"
+    printf '  %s --all                  # run every tNNN_* bundle in this dir\n' "$(basename "$0")"
+    printf '  %s path/to/script.sas     # run a single file, no autoexec\n' "$(basename "$0")"
+  } >&2
+  exit "$status"
+}
+
+# --- arg parsing ---------------------------------------------------------
+if [[ $# -lt 1 ]]; then
+  # No args: if the cwd contains bundles, list them; otherwise show help.
+  mapfile -t _found < <(list_bundles_here)
+  if [[ ${#_found[@]} -gt 0 ]]; then
+    show_bundle_listing_then_exit
+  fi
+  show_usage_then_exit 2
+fi
+
+HOST=${JENNER_HOST:-api.jenneranalytics.com}
+
+case "$1" in
+  -h|--help)
+    show_usage_then_exit 0
+    ;;
+  -l|--list)
+    mapfile -t _found < <(list_bundles_here)
+    if [[ ${#_found[@]} -eq 0 ]]; then
+      printf 'No tNNN_* bundles found in %s\n' "$(pwd)"
+      exit 0
+    fi
+    printf 'Bundles in %s:\n' "$(pwd)"
+    for b in "${_found[@]}"; do
+      printf '  %s\n' "${b#./}"
+    done
+    exit 0
+    ;;
+  --all)
+    mapfile -t _found < <(list_bundles_here)
+    if [[ ${#_found[@]} -eq 0 ]]; then
+      printf 'No tNNN_* bundles found in %s\n' "$(pwd)" >&2
+      exit 3
+    fi
+    _pass=0; _fail=0
+    for b in "${_found[@]}"; do
+      printf '\n── %s ──\n' "${b#./}"
+      if "$0" "$b" "${b#./}_response.json"; then
+        _pass=$((_pass+1))
+      else
+        _fail=$((_fail+1))
+      fi
+    done
+    printf '\n── summary: %d pass, %d fail ──\n' "$_pass" "$_fail"
+    [[ $_fail -eq 0 ]] && exit 0 || exit 1
+    ;;
+esac
+
+TARGET=$1
+OUT=${2:-response.json}
+
+# --- assemble the submission body ---------------------------------------
+# If TARGET is a directory, treat it as a bundle. If it's a file, submit
+# it directly.
+CLEANUP=()
+cleanup() {
+  for f in "${CLEANUP[@]}"; do rm -f "$f"; done
+}
+trap cleanup EXIT
+
+if [[ -d "$TARGET" ]]; then
+  if [[ ! -f "$TARGET/script.sas" ]]; then
+    printf 'error: %s is a directory but has no script.sas\n' "$TARGET" >&2
+    exit 3
+  fi
+  SUBMIT=$(mktemp -t jc_submit.XXXXXX.sas)
+  CLEANUP+=("$SUBMIT")
+  if [[ -f "$TARGET/autoexec.sas" ]]; then
+    cat "$TARGET/autoexec.sas" > "$SUBMIT"
+    printf '\n' >> "$SUBMIT"
+  fi
+  cat "$TARGET/script.sas" >> "$SUBMIT"
+  printf 'Submitting bundle: %s\n' "$TARGET"
+  if [[ -f "$TARGET/autoexec.sas" ]]; then
+    printf '  autoexec.sas (%d bytes) + script.sas (%d bytes)\n' \
+      "$(wc -c < "$TARGET/autoexec.sas")" "$(wc -c < "$TARGET/script.sas")"
+  else
+    printf '  script.sas (%d bytes), no autoexec\n' "$(wc -c < "$TARGET/script.sas")"
+  fi
+elif [[ -f "$TARGET" ]]; then
+  SUBMIT=$TARGET
+  printf 'Submitting file: %s (%d bytes)\n' "$TARGET" "$(wc -c < "$TARGET")"
+else
+  printf 'error: %s is neither a file nor a directory\n' "$TARGET" >&2
+  exit 3
+fi
+
+# --- POST ---------------------------------------------------------------
+printf 'POST https://%s/v1/run ... ' "$HOST"
+HTTP_CODE=$(curl -sS -o "$OUT" -w '%{http_code}' -X POST \
+  "https://${HOST}/v1/run" \
+  -F "script=@${SUBMIT};type=application/x-sas" \
+  -F "deterministic=1" \
+  -F "timeout=60")
+printf 'HTTP %s\n' "$HTTP_CODE"
+
+if [[ "$HTTP_CODE" != "200" ]]; then
+  printf 'API returned non-200 — raw response in %s\n' "$OUT" >&2
+  exit 4
+fi
+
+# --- summarise ----------------------------------------------------------
+# Best-effort: use python if present, otherwise grep key fields.
+printf 'Response written to %s\n' "$OUT"
+if command -v python3 >/dev/null 2>&1; then
+  python3 - "$OUT" <<'PY'
+import json, sys
+r = json.load(open(sys.argv[1]))
+print(f"  status     : {r.get('status')}")
+print(f"  exit_code  : {r.get('exit_code')}")
+print(f"  duration_ms: {r.get('duration_ms')}")
+print(f"  run_id     : {r.get('run_id')}")
+print(f"  jenner_ver : {r.get('jenner_version')}")
+log = r.get('log', '')
+if log:
+    print('  log (first 10 lines):')
+    for line in log.splitlines()[:10]:
+        print(f'    {line}')
+PY
+else
+  printf '  (install python3 for a pretty summary; raw JSON in %s)\n' "$OUT"
+fi

--- a/jenner-check/t002_macro_minmaxgrades/autoexec.sas
+++ b/jenner-check/t002_macro_minmaxgrades/autoexec.sas
@@ -1,0 +1,58 @@
+options obs=100;
+
+/* ------------------------------------------------------------------ *
+ * Macro under test: %minmaxgrades  (Macros/MinMaxGrades.sas)
+ *
+ * The macro is a DATA-step body: given per-grade enrollment counts
+ * (AO, ps, pk, k, _1 .. _12) it flags adult-only schools and derives
+ * the lowest (grade_min) and highest (grade_max) grade offered.
+ * Reproduced verbatim below so the bundle exercises the author's
+ * logic; the caller DATA step supplies a small mock enrollment file.
+ * ------------------------------------------------------------------ */
+
+%macro minmaxgrades ();
+
+/* Flag adult-only school */
+if AO >0 then do;
+	adult_flag = 1;
+end;
+
+else do;
+
+	/* Flag lowest grade */
+	if ps > 0 then grade_min = -2;
+		else if pk > 0 then grade_min = -1;
+		else if k > 0 then grade_min = 0;
+		else if _1 > 0 then grade_min = 1;
+		else if _2 > 0 then grade_min = 2;
+		else if _3 > 0 then grade_min = 3;
+		else if _4 > 0 then grade_min = 4;
+		else if _5 > 0 then grade_min = 5;
+		else if _6 > 0 then grade_min = 6;
+		else if _7 > 0 then grade_min = 7;
+		else if _8 > 0 then grade_min = 8;
+		else if _9 > 0 then grade_min = 9;
+		else if _10 > 0 then grade_min = 10;
+		else if _11 > 0 then grade_min = 10;
+		else if _12 > 0 then grade_min = 12;
+
+	/* Flag highest grade */
+	if _12 > 0 then grade_max = 12;
+		else if _11 > 0 then grade_max = 11;
+		else if _10 > 0 then grade_max = 10;
+		else if _9 > 0 then grade_max = 9;
+		else if _8 > 0 then grade_max = 8;
+		else if _7 > 0 then grade_max = 7;
+		else if _6 > 0 then grade_max = 6;
+		else if _5 > 0 then grade_max = 5;
+		else if _4 > 0 then grade_max = 4;
+		else if _3 > 0 then grade_max = 3;
+		else if _2 > 0 then grade_max = 5;
+		else if _1 > 0 then grade_max = 1;
+		else if k > 0 then grade_max = 0;
+		else if pk > 0 then grade_max = -1;
+		else if ps > 0 then grade_max = -2;
+
+end;
+
+%mend minmaxgrades;

--- a/jenner-check/t002_macro_minmaxgrades/expected.json
+++ b/jenner-check/t002_macro_minmaxgrades/expected.json
@@ -1,0 +1,18 @@
+{
+  "_captured_at": "2026-06-17T16:40:36Z",
+  "_captured_run_id": "r_019ed67457817cc3af91e0fe56359656",
+  "status": "ok",
+  "exit_code": 0,
+  "log_contains": [
+    "NOTE: Wrote enroll (5 rows, 17 columns).",
+    "NOTE: Wrote enroll_flagged (5 rows, 20 columns)."
+  ],
+  "log_does_not_contain": [
+    "ERROR:",
+    "[JENNER-ERROR"
+  ],
+  "diagnostics": {
+    "parse_warnings": [],
+    "runtime_warnings": []
+  }
+}

--- a/jenner-check/t002_macro_minmaxgrades/expected/files.md
+++ b/jenner-check/t002_macro_minmaxgrades/expected/files.md
@@ -1,0 +1,15 @@
+These URLs point at a specific Jenner run and expire when that run is reaped; re-running the bundle (./run_jenner.sh t002_macro_minmaxgrades) regenerates them.
+
+
+## Files
+
+| name | content_type | size_bytes | url |
+|---|---|---|---|
+| listing.txt | text/plain | 335 | https://api.jenneranalytics.com/v1/run/r_019ed67457817cc3af91e0fe56359656/files/listing.txt?token=475e6089da534d5b9d1f0aef92a7c43b |
+
+## Datasets
+
+| name | rows | columns | preview_url |
+|---|---|---|---|
+| enroll | 5 | 17 | https://api.jenneranalytics.com/v1/run/r_019ed67457817cc3af91e0fe56359656/datasets/enroll?token=475e6089da534d5b9d1f0aef92a7c43b |
+| enroll_flagged | 5 | 20 | https://api.jenneranalytics.com/v1/run/r_019ed67457817cc3af91e0fe56359656/datasets/enroll_flagged?token=475e6089da534d5b9d1f0aef92a7c43b |

--- a/jenner-check/t002_macro_minmaxgrades/expected/log.txt
+++ b/jenner-check/t002_macro_minmaxgrades/expected/log.txt
@@ -1,0 +1,24 @@
+Jenner 0.1.0 (Unlicensed - limited to 100 observations)
+Get a license at https://jenneranalytics.com/license
+
+NOTE: Option OBS changed to 100.
+NOTE: DATA enroll
+
+NOTE: Processing inline DATALINES (5 lines)
+
+NOTE: Read 5 rows from DATALINES.
+NOTE: Wrote enroll (5 rows, 17 columns).
+NOTE: DATA elapsed:
+  wall  0.00 seconds
+  cpu   0.00 seconds
+NOTE: DATA enroll_flagged
+
+
+NOTE: Read 5 rows from enroll.
+NOTE: Wrote enroll_flagged (5 rows, 20 columns).
+NOTE: DATA elapsed:
+  wall  0.00 seconds
+  cpu   0.00 seconds
+NOTE: PROC PRINT data=enroll_flagged
+
+NOTE: PROC PRINT completed: 5 observations printed, 4 variables

--- a/jenner-check/t002_macro_minmaxgrades/expected/output.txt
+++ b/jenner-check/t002_macro_minmaxgrades/expected/output.txt
@@ -1,0 +1,9 @@
+                                        Min / max grade flags from %minmaxgrades                                        
+
+ school  adult_flag  grade_min  grade_max
+ElemA             .         -1          4
+MiddleB           .          6          8
+HighC             .          9         12
+PkOnlyD           .         -1         -1
+AdultE            1          .          .
+

--- a/jenner-check/t002_macro_minmaxgrades/meta.json
+++ b/jenner-check/t002_macro_minmaxgrades/meta.json
@@ -1,0 +1,8 @@
+{
+  "bundle": "t002_macro_minmaxgrades",
+  "source_file": "Macros/MinMaxGrades.sas",
+  "source_blob_sha": "397e58aab93a16f384026932ab631e966f042b48",
+  "source_commit": "f72f4382088f2c66e3f73e1784dd2c4cb9da5d30",
+  "tier": "real_data",
+  "notes": "Caller for %minmaxgrades (macro reproduced verbatim): derives adult_flag / grade_min / grade_max from per-grade enrollment counts over 5 mock schools."
+}

--- a/jenner-check/t002_macro_minmaxgrades/script.sas
+++ b/jenner-check/t002_macro_minmaxgrades/script.sas
@@ -1,0 +1,29 @@
+/**************************************************************************
+ Caller for %minmaxgrades  (Macros/MinMaxGrades.sas)
+
+ Builds a small mock enrollment file with the per-grade count columns
+ the macro reads, then invokes the macro inside a DATA step exactly as
+ the production enrollment programs do (e.g. Prog/Enrollment/minmax_*).
+ Each row is a school; the macro derives adult_flag, grade_min, grade_max.
+**************************************************************************/
+
+data enroll;
+  input school $ AO ps pk k _1 _2 _3 _4 _5 _6 _7 _8 _9 _10 _11 _12;
+  datalines;
+ElemA   0  0 12 18 20 19 21 17  0  0  0  0  0  0  0  0  0
+MiddleB 0  0  0  0  0  0  0  0  0 22 24 23  0  0  0  0  0
+HighC   0  0  0  0  0  0  0  0  0  0  0  0 30 28 27 25  0
+PkOnlyD 0  0 15  0  0  0  0  0  0  0  0  0  0  0  0  0  0
+AdultE  9  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
+;
+run;
+
+data enroll_flagged;
+  set enroll;
+  %minmaxgrades()
+run;
+
+proc print data=enroll_flagged noobs;
+  var school adult_flag grade_min grade_max;
+  title 'Min / max grade flags from %minmaxgrades';
+run;

--- a/jenner-check/t003_macro_block10_to_seniorhigh/autoexec.sas
+++ b/jenner-check/t003_macro_block10_to_seniorhigh/autoexec.sas
@@ -1,0 +1,29 @@
+options obs=100;
+
+/* ------------------------------------------------------------------ *
+ * Macro under test: %Block10_to_seniorhigh
+ *                   (Macros/Block10_to_seniorhigh.sas)
+ *
+ * Maps a 2010 Census block ID to a DC Senior High School Attendance
+ * Zone via the $bk1seniorhigh. format, optionally applying the
+ * display format $seniorhigha. The production run sources both formats
+ * from the Schools format catalog; here we stand up small mock formats
+ * with the same names so the macro's PUT() + label + conditional
+ * FORMAT logic can run. The macro body itself is reproduced verbatim
+ * in script.sas.
+ * ------------------------------------------------------------------ */
+
+proc format;
+  /* block-id -> zone code (one char) */
+  value $bk1seniorhigh
+    '110010001001000' = 'A'
+    '110010002001001' = 'B'
+    '110010003002005' = 'C'
+    other             = 'Z';
+  /* zone code -> display label */
+  value $seniorhigha
+    'A' = 'Anacostia HS Zone'
+    'B' = 'Ballou HS Zone'
+    'C' = 'Cardozo HS Zone'
+    'Z' = 'Unzoned';
+run;

--- a/jenner-check/t003_macro_block10_to_seniorhigh/expected.json
+++ b/jenner-check/t003_macro_block10_to_seniorhigh/expected.json
@@ -1,0 +1,18 @@
+{
+  "_captured_at": "2026-06-17T16:40:36Z",
+  "_captured_run_id": "r_019ed6745d167680a9ebffd466a4c42e",
+  "status": "ok",
+  "exit_code": 0,
+  "log_contains": [
+    "NOTE: Wrote blocks (4 rows, 1 columns).",
+    "NOTE: Wrote zoned (4 rows, 2 columns)."
+  ],
+  "log_does_not_contain": [
+    "ERROR:",
+    "[JENNER-ERROR"
+  ],
+  "diagnostics": {
+    "parse_warnings": [],
+    "runtime_warnings": []
+  }
+}

--- a/jenner-check/t003_macro_block10_to_seniorhigh/expected/files.md
+++ b/jenner-check/t003_macro_block10_to_seniorhigh/expected/files.md
@@ -1,0 +1,15 @@
+These URLs point at a specific Jenner run and expire when that run is reaped; re-running the bundle (./run_jenner.sh t003_macro_block10_to_seniorhigh) regenerates them.
+
+
+## Files
+
+| name | content_type | size_bytes | url |
+|---|---|---|---|
+| listing.txt | text/plain | 260 | https://api.jenneranalytics.com/v1/run/r_019ed6745d167680a9ebffd466a4c42e/files/listing.txt?token=08cbdd1faa4449b8ae3f93015affc528 |
+
+## Datasets
+
+| name | rows | columns | preview_url |
+|---|---|---|---|
+| blocks | 4 | 1 | https://api.jenneranalytics.com/v1/run/r_019ed6745d167680a9ebffd466a4c42e/datasets/blocks?token=08cbdd1faa4449b8ae3f93015affc528 |
+| zoned | 4 | 2 | https://api.jenneranalytics.com/v1/run/r_019ed6745d167680a9ebffd466a4c42e/datasets/zoned?token=08cbdd1faa4449b8ae3f93015affc528 |

--- a/jenner-check/t003_macro_block10_to_seniorhigh/expected/log.txt
+++ b/jenner-check/t003_macro_block10_to_seniorhigh/expected/log.txt
@@ -1,0 +1,28 @@
+Jenner 0.1.0 (Unlicensed - limited to 100 observations)
+Get a license at https://jenneranalytics.com/license
+
+NOTE: Option OBS changed to 100.
+NOTE: PROC FORMAT library=WORK
+
+NOTE: FORMAT $bk1seniorhigh defined (4 ranges).
+NOTE: FORMAT $seniorhigha defined (4 ranges).
+NOTE: DATA blocks
+
+NOTE: Processing inline DATALINES (4 lines)
+
+NOTE: Read 4 rows from DATALINES.
+NOTE: Wrote blocks (4 rows, 1 columns).
+NOTE: DATA elapsed:
+  wall  0.00 seconds
+  cpu   0.00 seconds
+NOTE: DATA zoned
+
+
+NOTE: Read 4 rows from blocks.
+NOTE: Wrote zoned (4 rows, 2 columns).
+NOTE: DATA elapsed:
+  wall  0.00 seconds
+  cpu   0.00 seconds
+NOTE: PROC PRINT data=zoned
+
+NOTE: PROC PRINT completed: 4 observations printed, 2 variables

--- a/jenner-check/t003_macro_block10_to_seniorhigh/expected/output.txt
+++ b/jenner-check/t003_macro_block10_to_seniorhigh/expected/output.txt
@@ -1,0 +1,8 @@
+                                  Census blocks mapped to Senior High Attendance Zones                                  
+
+     geoblk2010  Senior High School Attendance Zone
+110010001001000  Anacostia HS Zone
+110010002001001  Ballou HS Zone
+110010003002005  Cardozo HS Zone
+110019999999999  Unzoned
+

--- a/jenner-check/t003_macro_block10_to_seniorhigh/meta.json
+++ b/jenner-check/t003_macro_block10_to_seniorhigh/meta.json
@@ -1,0 +1,8 @@
+{
+  "bundle": "t003_macro_block10_to_seniorhigh",
+  "source_file": "Macros/Block10_to_seniorhigh.sas",
+  "source_blob_sha": "fc873f522ab640258daa9f2fa49c8fa94d9b94d8",
+  "source_commit": "f72f4382088f2c66e3f73e1784dd2c4cb9da5d30",
+  "tier": "real_data",
+  "notes": "Caller for %Block10_to_seniorhigh (macro reproduced verbatim): maps 2010 Census block IDs to DC Senior High Attendance Zones via mock $bk1seniorhigh./$seniorhigha. formats with format=Y."
+}

--- a/jenner-check/t003_macro_block10_to_seniorhigh/script.sas
+++ b/jenner-check/t003_macro_block10_to_seniorhigh/script.sas
@@ -1,0 +1,41 @@
+/**************************************************************************
+ Caller for %Block10_to_seniorhigh  (Macros/Block10_to_seniorhigh.sas)
+
+ The macro definition is reproduced verbatim, then invoked over a small
+ mock block file with format=Y so the display format branch executes.
+**************************************************************************/
+
+%macro Block10_to_seniorhigh( invar=geoblk2010, outvar=seniorhigh, format=N );
+
+  length &outvar $ 1;
+
+  &outvar = put( &invar, $bk1seniorhigh. );
+
+  label &outvar = "Senior High School Attendance Zone ";
+
+  %if %upcase( &format ) = Y %then %do;
+    format &outvar $seniorhigha.;
+  %end;
+
+%mend Block10_to_seniorhigh;
+
+data blocks;
+  length geoblk2010 $ 15;
+  input geoblk2010 $;
+  datalines;
+110010001001000
+110010002001001
+110010003002005
+110019999999999
+;
+run;
+
+data zoned;
+  set blocks;
+  %Block10_to_seniorhigh( invar=geoblk2010, outvar=seniorhigh, format=Y )
+run;
+
+proc print data=zoned noobs label;
+  var geoblk2010 seniorhigh;
+  title 'Census blocks mapped to Senior High Attendance Zones';
+run;

--- a/jenner-check/t004_school_formats_grade/autoexec.sas
+++ b/jenner-check/t004_school_formats_grade/autoexec.sas
@@ -1,0 +1,1 @@
+options obs=100;

--- a/jenner-check/t004_school_formats_grade/expected.json
+++ b/jenner-check/t004_school_formats_grade/expected.json
@@ -1,0 +1,17 @@
+{
+  "_captured_at": "2026-06-17T16:40:36Z",
+  "_captured_run_id": "r_019ed67462a4782391e2f9a393c43880",
+  "status": "ok",
+  "exit_code": 0,
+  "log_contains": [
+    "NOTE: Wrote schools (6 rows, 3 columns)."
+  ],
+  "log_does_not_contain": [
+    "ERROR:",
+    "[JENNER-ERROR"
+  ],
+  "diagnostics": {
+    "parse_warnings": [],
+    "runtime_warnings": []
+  }
+}

--- a/jenner-check/t004_school_formats_grade/expected/files.md
+++ b/jenner-check/t004_school_formats_grade/expected/files.md
@@ -1,0 +1,16 @@
+These URLs point at a specific Jenner run and expire when that run is reaped; re-running the bundle (./run_jenner.sh t004_school_formats_grade) regenerates them.
+
+
+## Files
+
+| name | content_type | size_bytes | url |
+|---|---|---|---|
+| listing.txt | text/plain | 284 | https://api.jenneranalytics.com/v1/run/r_019ed67462a4782391e2f9a393c43880/files/listing.txt?token=0c0de4db2c4d47de816cd244c52ba95b |
+| ods_output/freq_sch_type.png | image/png | 16129 | https://api.jenneranalytics.com/v1/run/r_019ed67462a4782391e2f9a393c43880/files/ods_output/freq_sch_type.png?token=0c0de4db2c4d47de816cd244c52ba95b |
+| ods_output/freq_sch_type.svg | image/svg+xml | 10321 | https://api.jenneranalytics.com/v1/run/r_019ed67462a4782391e2f9a393c43880/files/ods_output/freq_sch_type.svg?token=0c0de4db2c4d47de816cd244c52ba95b |
+
+## Datasets
+
+| name | rows | columns | preview_url |
+|---|---|---|---|
+| schools | 6 | 3 | https://api.jenneranalytics.com/v1/run/r_019ed67462a4782391e2f9a393c43880/datasets/schools?token=0c0de4db2c4d47de816cd244c52ba95b |

--- a/jenner-check/t004_school_formats_grade/expected/log.txt
+++ b/jenner-check/t004_school_formats_grade/expected/log.txt
@@ -1,0 +1,21 @@
+Jenner 0.1.0 (Unlicensed - limited to 100 observations)
+Get a license at https://jenneranalytics.com/license
+
+NOTE: Option OBS changed to 100.
+NOTE: PROC FORMAT library=WORK
+
+NOTE: FORMAT $SchType defined (2 ranges).
+NOTE: DATA schools
+
+NOTE: Processing inline DATALINES (6 lines)
+
+NOTE: Read 6 rows from DATALINES.
+NOTE: Wrote schools (6 rows, 3 columns).
+NOTE: DATA elapsed:
+  wall  0.00 seconds
+  cpu   0.00 seconds
+NOTE: PROC FREQ
+NOTE: ODS plot written: freq_sch_type.spec.json
+NOTE: PROC FREQ statement used.
+NOTE: PROC MEANS
+NOTE: PROC MEANS statement used.

--- a/jenner-check/t004_school_formats_grade/expected/output.txt
+++ b/jenner-check/t004_school_formats_grade/expected/output.txt
@@ -1,0 +1,20 @@
+                                    School counts by type (School Formats $SchType)                                     
+
+                                                   The FREQ Procedure
+
+sch_type    Frequency    Percent
+---------------------------------
+0                   3     50.00
+1                   3     50.00
+                                               Enrollment by school type                                                
+
+                                                  The MEANS Procedure
+
+                                              Analysis Variable : enrolled
+
+        sch_type          N Obs            Sum           Mean
+        -----------------------------------------------------
+        0                     3         1325.0          441.7
+        1                     3         2965.0          988.3
+        -----------------------------------------------------
+

--- a/jenner-check/t004_school_formats_grade/meta.json
+++ b/jenner-check/t004_school_formats_grade/meta.json
@@ -1,0 +1,8 @@
+{
+  "bundle": "t004_school_formats_grade",
+  "source_file": "Prog/School Formats.sas",
+  "source_blob_sha": "9afb980d01fbbc33053e237dbcf3eddd86b31d1f",
+  "source_commit": "f72f4382088f2c66e3f73e1784dd2c4cb9da5d30",
+  "tier": "real_data",
+  "notes": "$SchType VALUE block reproduced verbatim from School Formats.sas, applied to a mock school file via PROC FREQ + PROC MEANS class."
+}

--- a/jenner-check/t004_school_formats_grade/script.sas
+++ b/jenner-check/t004_school_formats_grade/script.sas
@@ -1,0 +1,45 @@
+/**************************************************************************
+ Program:  School Formats  (Prog/School Formats.sas)  -- $SchType block
+ Project:  SCHOOLS DCDATA
+ Author:   S. Litschwartz
+
+ The source program builds the Schools format catalog. The $SchType
+ VALUE block below is reproduced verbatim from the program; the
+ data-driven %Data_to_format steps that follow it in the original
+ require the master school file library and are out of scope for an
+ isolated run. Here the format is applied to a small mock school file
+ and tabulated, exercising the format definition end to end.
+**************************************************************************/
+
+proc format;
+value $SchType
+"0"="Charter"
+"1"="DCPS"
+;
+run;
+
+data schools;
+  length sch_type $ 1 school $ 12;
+  input sch_type $ school $ enrolled;
+  datalines;
+1 Wilson      1455
+1 Eastern      820
+1 Ballou       690
+0 KIPPDC       540
+0 DCIntl       410
+0 Friendship   375
+;
+run;
+
+proc freq data=schools;
+  tables sch_type / nocum;
+  format sch_type $SchType.;
+  title 'School counts by type (School Formats $SchType)';
+run;
+
+proc means data=schools n sum mean maxdec=1;
+  class sch_type;
+  var enrolled;
+  format sch_type $SchType.;
+  title 'Enrollment by school type';
+run;


### PR DESCRIPTION
[Jenneranalytics.com](https://jenneranalytics.com) provides an API that runs SAS code, with support for more than 200 SAS procedures. You can also use it with Anthropic Claude Code AI in a collaborative workspace. It's available for Mac on the Apple App Store, and by license for Windows and Linux. Your SAS code here runs on it unmodified — this PR adds a few small compatibility bundles, built from your own programs, so you can see it for yourself.

The new `jenner-check/` directory holds three self-contained bundles and a runner:

```
jenner-check/
├── run_jenner.sh / .bat / .sas       # runner (mac/linux, windows, base SAS)
├── t002_macro_minmaxgrades/          # caller for %minmaxgrades
├── t003_macro_block10_to_seniorhigh/ # caller for %Block10_to_seniorhigh
└── t004_school_formats_grade/        # the $SchType format, applied
```

Run them from inside that directory with `./run_jenner.sh --all` (or `%include 'run_jenner.sas';` from a SAS session); each prints its status and ends with a pass/fail summary.

One thing I appreciated reading through the repo: the two macros in `Macros/` are written as clean, reusable DATA-step bodies — `%minmaxgrades` deriving min/max grade flags from the per-grade enrollment columns, and `%Block10_to_seniorhigh` mapping Census blocks to attendance zones through a format — which made them straightforward to lift into standalone tests. The consistent program headers across `Prog/` made it easy to find my way around, too.

No response needed — merge, close, or ignore as you like. If you'd rather not get PRs like this in future, reply with `no-more-prs` in any comment or open an issue titled `jenner-check: opt out`.

---

Lawrence W. Sinclair  
CEO / Jenner Analytics Ltd  
[jenneranalytics.com](https://jenneranalytics.com)  
[linkedin.com/in/lwsinclair/](https://www.linkedin.com/in/lwsinclair/)